### PR TITLE
Instantiate HibernateFilterConnectionSourceFactory with domains

### DIFF
--- a/hibernate-filter-plugin/src/main/groovy/org.grails.plugin.hibernate.filter/HibernateFilterGrailsPlugin.groovy
+++ b/hibernate-filter-plugin/src/main/groovy/org.grails.plugin.hibernate.filter/HibernateFilterGrailsPlugin.groovy
@@ -6,43 +6,45 @@ import org.grails.core.artefact.DomainClassArtefactHandler
 
 class HibernateFilterGrailsPlugin extends Plugin {
 
-	// the version or versions of Grails the plugin is designed for
-	def grailsVersion = "3.2.3 > *"
-	def loadAfter = ['controllers', 'hibernate']
-	def observe = ['*']
-	def pluginExcludes = []
+    // the version or versions of Grails the plugin is designed for
+    def grailsVersion = "3.2.3 > *"
+    def loadAfter = ['controllers', 'hibernate']
+    def observe = ['*']
+    def pluginExcludes = []
 
-	def author = 'Scott Burch'
-	def authorEmail = 'scott@bulldoginfo.com'
-	def title = 'Hibernate Filter plugin'
-	def description = 'Integrates Hibernate filtering into Grails 3'
-	def documentation = 'http://grails.org/plugin/hibernate-filter'
+    def author = 'Scott Burch'
+    def authorEmail = 'scott@bulldoginfo.com'
+    def title = 'Hibernate Filter plugin'
+    def description = 'Integrates Hibernate filtering into Grails 3'
+    def documentation = 'http://grails.org/plugin/hibernate-filter'
 
-	def license = 'APACHE'
-	def developers = [
-			[name: 'Burt Beckwith', email: 'beckwithb@vmware.com'],
-			[name: 'Alex Shneyderman', email: 'a.shneyderman@gmail.com'],
-			[name: 'Piotr Chowaniec', email: 'piotr.chowaniec@gmail.com'],
-			[name: 'Alex Kramer', email: 'ackramer19@gmail.com']]
-	def issueManagement = [system: 'GitHub', url: 'https://github.com/alexkramer/grails-hibernate-filter/issues']
-	def scm = [url: 'https://github.com/alexkramer/grails-hibernate-filter']
-	def profiles = ['web']
+    def license = 'APACHE'
+    def developers = [
+            [name: 'Burt Beckwith', email: 'beckwithb@vmware.com'],
+            [name: 'Alex Shneyderman', email: 'a.shneyderman@gmail.com'],
+            [name: 'Piotr Chowaniec', email: 'piotr.chowaniec@gmail.com'],
+            [name: 'Alex Kramer', email: 'ackramer19@gmail.com']]
+    def issueManagement = [system: 'GitHub', url: 'https://github.com/alexkramer/grails-hibernate-filter/issues']
+    def scm = [url: 'https://github.com/alexkramer/grails-hibernate-filter']
+    def profiles = ['web']
 
-	void doWithDynamicMethods() {
-		for( GrailsClass dc in grailsApplication.getArtefacts( DomainClassArtefactHandler.TYPE ) ) {
-			HibernateFilterUtils.addDomainClassMethods dc.clazz, getApplicationContext()
-		}
-
-		for( Class artefactClass in grailsApplication.allArtefacts ) {
-			HibernateFilterUtils.addDomainProxies artefactClass
-		}
-	}
-
-    Closure doWithSpring() {{->
-        hibernateConnectionSourceFactory(HibernateFilterConnectionSourceFactory)
-
-        hibernateFilterInterceptor(HibernateFilterInterceptor) {
-            sessionFactory = sessionFactory
+    void doWithDynamicMethods() {
+        for (GrailsClass dc in grailsApplication.getArtefacts(DomainClassArtefactHandler.TYPE)) {
+            HibernateFilterUtils.addDomainClassMethods dc.clazz, getApplicationContext()
         }
-    }}
+
+        for (Class artefactClass in grailsApplication.allArtefacts) {
+            HibernateFilterUtils.addDomainProxies artefactClass
+        }
+    }
+
+    Closure doWithSpring() {
+        { ->
+            def domainClasses = grailsApplication.getArtefacts(DomainClassArtefactHandler.TYPE)
+            hibernateConnectionSourceFactory(HibernateFilterConnectionSourceFactory, domainClasses*.clazz)
+            hibernateFilterInterceptor(HibernateFilterInterceptor) {
+                sessionFactory = sessionFactory
+            }
+        }
+    }
 }


### PR DESCRIPTION
In order to fix https://github.com/alexkramer/grails-hibernate-filter/issues/3,
the domain classes need to be passed as arguments to hibernateConnectionSourceFactory
bean constructor.