### PR TITLE
Use the deprecated way of checking if a class is a root domain class or not 

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ Add dependency in build.gradle:
     }
     
     dependencies {
-        compile "org.grails.plugins:hibernate-filter-plugin:0.5.4"
+        compile "org.grails.plugins:hibernate-filter-plugin:0.5.5"
     }
 
 # Usage

--- a/hibernate-filter-plugin/build.gradle
+++ b/hibernate-filter-plugin/build.gradle
@@ -13,7 +13,7 @@ buildscript {
     }
 }
 
-version "0.5.4"
+version "0.5.5"
 group "org.grails.plugins"
 
 apply plugin: 'maven-publish'

--- a/hibernate-filter-plugin/src/main/groovy/org.grails.plugin.hibernate.filter/HibernateFilterBuilder.groovy
+++ b/hibernate-filter-plugin/src/main/groovy/org.grails.plugin.hibernate.filter/HibernateFilterBuilder.groovy
@@ -1,6 +1,7 @@
 package org.grails.plugin.hibernate.filter
 
 import grails.core.GrailsDomainClass
+import org.grails.core.artefact.DomainClassArtefactHandler
 import org.hibernate.boot.spi.InFlightMetadataCollector
 import org.hibernate.engine.spi.FilterDefinition
 import org.hibernate.mapping.PersistentClass
@@ -74,7 +75,7 @@ class HibernateFilterBuilder {
                 persistentClass
 
         if (entity == null) {
-            if (options.collection && !domainClass.isRoot()) {
+            if (options.collection && !isRoot(domainClass)) {
                 def clazz = domainClass.clazz.superclass
                 while (clazz != Object && !entity) {
                     entity = mappings.getCollectionBinding("${clazz.name}.$options.collection")
@@ -105,9 +106,14 @@ class HibernateFilterBuilder {
         }
 
         // store any domain alias proxies to be injected later
-        if (options.aliasDomain && domainClass.isRoot()) {
+        if (options.aliasDomain && isRoot(domainClass)) {
             DefaultHibernateFiltersHolder.addDomainAliasProxy(
                     new HibernateFilterDomainProxy(domainClass.referenceInstance, options.aliasDomain, name))
         }
+    }
+
+    boolean isRoot(GrailsDomainClass domainClass) {
+        final Class<?> superClass = domainClass.getClass().getSuperclass()
+        DomainClassArtefactHandler.isDomainClass(superClass) ? false : true
     }
 }


### PR DESCRIPTION
Use the deprecated way of checking if a class is a root domain class or not for now, to make the plugin compatible with grails 3.3.9 applications and multiple data sources configured.

Error was obtained at startup:
org.grails.datastore.mapping.model.MappingContext.getPersistentEntity(java.lang.String)] cannot be accessed before GORM has initialized, which was triggered by domainCLass.isRoot()